### PR TITLE
Class firmware submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/midex-class-firmware"]
+	path = src/midex-class-firmware
+	url = git@github.com:sgorpi/midex-class-firmware.git

--- a/doc/Midex hardware components.md
+++ b/doc/Midex hardware components.md
@@ -31,4 +31,53 @@ PID 0x1010 - with ROM - R2 COMP
 
 PID 0x1001 - with latest firmware uploaded
 
+## r1
+ST16C454CJ
+- D1 = PIN 67 = connected to both ST16C454CJ and to the D1 pin of the EZUSB.
+- D2 = PIN 68 = connected to both ST16C454CJ and to the D2 pin of the EZUSB.
+- IOW = PIN 18 - connected to both ST16C454CJ and to the Output Enable pin of the PALL16V8. Also to the PC6/WR# pin of EZUSB
+- IOR = PIN 52 - connected to both ST16C454CJ and to the PC7/RD# pin of the EZUSB.
+- 16/-68 = PIN 31 - pulled down with 2.7kOhm on the first of the 2 ST16C454CJ, with 66kOhm on the second (which could thus be pulled up by the internal resistor)
+- INTC = pin 49 -> AN2131 pin 70 PA2/EO#
+- INTD = pin 55 -> AN2131 pin 71 PA3/CS#
 
+second ST16C454CJ
+- INTD = pin 55 -> AN2131 pin 76 PA7/RXD1 out
+
+PALLV16
+- some of the input pins seem connected to the SRAM
+- other input pins likely connected to EZUSB but untraceable.
+- pin 2 (i1) -> TH138D pin 5 (E2) -> 
+- pin 5 (i4) -> TH138D pin 6 (E3) -> SRAM pin 4
+- pin 6 (i5) -> ST16C454CJ pin 37 (RESET) --> EZUSB pin 52 (PB4/int4)
+- pin 7 (i6) -> ST16C454CJ pin 7 (RXA)
+- pin 28 (i/o6) -> SRAM pin 22 (OE) 
+
+TH138D
+- Pin 15 (Y0) -> st16c CSA (first ST16C)
+- Pin 14 (Y1) -> st16c CSB (first ST16C)
+- Pin 13 (Y2) -> st16c CSC (first ST16C)
+- Pin 12 (Y3) -> st16c CSD (first ST16C)
+- Pin 11 (Y4) -> st16c CSA (second ST16C)
+- Pin 10 (Y5) -> st16c CSB (second ST16C)
+- Pin 09 (Y6) -> st16c CSC (second ST16C)
+- Pin 07 (Y7) -> st16c CSD (second ST16C)
+
+
+## r2
+
+ST16C454CJ
+- pin 35 (XTAL1) - looks connected to ST16C452CJ CLK
+- pin 36 (XTAL2) - NC?
+
+74HC138D
+- Pin 15 (Y0) -> st16c CSA (first ST16C)
+- Pin 14 (Y1) -> st16c CSB (first ST16C)
+- Pin 13 (Y2) -> st16c CSC (first ST16C)
+- Pin 12 (Y3) -> st16c CSD (first ST16C)
+- Pin 11 (Y4) -> st16c452 CSA (second ST16C)
+- Pin 10 (Y5) -> st16c452 CSB (second ST16C)
+- Pin 09 (Y6) -> st16c452 ? (second ST16C)
+- Pin 07 (Y7) -> st16c452 ? (second ST16C)
+
+Alliance AS

--- a/doc/firmware_upload_process.md
+++ b/doc/firmware_upload_process.md
@@ -313,16 +313,25 @@ counts in `fw.json`.
   2002 installers `Midex8_V1_80.exe` / `updmros.exe`). The Mac kext is
   the **only available source** for MIDEX3 firmware in this repo.
 
-### Memory-map differences confirm separate chip targets
+### Memory-map differences show the images are device-specific
 
 All MIDEX8 r1 records fit in `0x0000-0x1508` (well inside the AN2131
-8 KB RAM), as do the MIDEX3 records (max `0x1692`). The MIDEX8 r2
-firmware additionally contains a single 1-byte write to `0x7FE5` — that
-address only exists on the CY7C646 FX family (FX configuration register
-region). Uploading `midex8r2_firmware` to an AN2131 chip would silently
-write to an invalid address; conversely, an AN2131-targeted blob will
-miss the FX register initialisation needed on r2. The blobs are
-genuinely device-specific and cannot be substituted for each other.
+8 KB RAM), as do the MIDEX3 records (max `0x1692`). The blobs are
+device-specific and cannot be substituted for each other — but the
+distinguishing factor is the **external MIDI/UART hardware and port
+count** each image drives, *not* the EZ-USB chip variant.
+
+> **Correction (2026-05-30):** an earlier version of this note claimed the
+> MIDEX8 r2 image's write to XDATA `0x7FE5` proved a CY7C646-FX-only
+> register and therefore a separate chip target. That is **wrong**.
+> `0x7FE5` is **AUTODATA** (the autopointer data register), and diffing the
+> two TRMs shows the AN2131 and CY7C646 FX have **byte-identical `0x7Fxx`
+> register maps** (the AN2131QC also has the autopointer / fast-transfer
+> block — see AN2131 TRM §1.14). So register usage does **not** distinguish
+> the two chips, and the EZ-USB MCU variant of MIDEX3 **cannot be confirmed
+> from firmware alone** — definitive chip ID needs the physical PCB chip
+> marking or the loader-mode silicon ID. The images remain device-specific
+> because of their differing external UART layout / MIDI port count.
 
 ### Outcome
 


### PR DESCRIPTION
- Link to a submodule repo that provides USB class-compliant firmware for the MIDEX8 r1 / r2
